### PR TITLE
Update README.md (step 14_gpts / 01_create_gpt -> "Creating a Custom GPT")

### DIFF
--- a/14_gpts/01_create_gpt/readme.md
+++ b/14_gpts/01_create_gpt/readme.md
@@ -4,7 +4,7 @@ Detailed guide on creating a custom GPT with OpenAI:
 
 **Prerequisites:**
 
-* An OpenAI account with a ChatGPT Plus or Enterprise subscription (Custom GPTs are not available on free plans).
+* An OpenAI account. Free users have limited access to Custom GPTs. A ChatGPT Plus subscription ($20/month) provides enhanced access compared to free users, while an Enterprise subscription offers the highest level of access and benefits.
 
 **Steps:**
 


### PR DESCRIPTION
I noticed that the guide in (step 14_gpts / 01_create_gpt) mentions custom GPTs require a chatGPT plus or enterprise subscription. Although free users now have access to custom GPTs, their access is limited. I have updated the guide to reflect this more accurately. You can review the changes in my pull request 