### PR TITLE
Fix: Remove optional union in WeatherSanitizer schema to resolve BadRequestError

### DIFF
--- a/01_ai_agents_first/18_guardrails/saftey_rails/main.py
+++ b/01_ai_agents_first/18_guardrails/saftey_rails/main.py
@@ -25,7 +25,7 @@ llm_model: OpenAIChatCompletionsModel = OpenAIChatCompletionsModel(
 
 class WeatherSanitizer(BaseModel):
     weather_related: bool
-    reason: str | None = None
+    reason: str
 
 weather_sanitizer = Agent(
     name="WeatherSanitizer",


### PR DESCRIPTION
**This PR updates the WeatherSanitizer Pydantic model by removing the str | None = None type annotation from the reason field.**

### **Problem**

When running Runner.run with the WeatherSanitizer agent, the following error occurred:

`openai.BadRequestError: Error code: 400 - [{'error': {'code': 400, 'message': "Unable to submit request because one or more response schemas didn't specify the schema type field."}}]`


The issue is caused by the reason: str | None = None definition, which generates a schema without the expected "type" field, making it incompatible with the response schema validator used by the Agents SDK.

### **Solution**

Changed the field definition from:

`reason: str | None = None`


to

`reason: str `

### **Result**

- Fixes the BadRequestError when running the agent.
- Ensures that the schema generated for WeatherSanitizer includes a valid type.
