### PR TITLE
fixed 404 error

### DIFF
--- a/01_ai_agents_first/07_model_settings/hello_agent/README.md
+++ b/01_ai_agents_first/07_model_settings/hello_agent/README.md
@@ -60,7 +60,7 @@ This module teaches you how to fine-tune your AI agents using **Model Settings**
 
 ## 🔗 Related Modules
 
-- **Previous**: [Basic Tools](../06_basic_tools/) - Learn about tools
+- **Previous**: [Basic Tools](../../06_basic_tools/) - Learn about tools
 - **Next**: [Advanced Tools](../08_advanced_tools/) - Master tool usage
 
 ## 🎓 Tips for Success


### PR DESCRIPTION
fixed : 
404 - page not found
The main branch of learn-agentic-ai does not contain the path  01_ai_agents_first/07_model_settings/06_basic_tools.