### PR TITLE
feat: add Astraflow provider support and configuration examples

### DIFF
--- a/-01_lets_get_started/00_which_llm/readme.md
+++ b/-01_lets_get_started/00_which_llm/readme.md
@@ -101,6 +101,58 @@ For a true test, I’d throw a challenging prompt at them—like designing a mul
 
 ---
 
+## Astraflow: A Cost-Efficient Multi-Model Aggregation Platform
+
+[Astraflow](https://astraflow.ucloud-global.com) by **UCloud (优刻得)** is an OpenAI-compatible AI model aggregation platform that gives you access to **200+ models** (GPT-4o, Claude, Gemini, DeepSeek, Llama, Mistral, and more) through a single API key. Because it is fully OpenAI-compatible, you can use it with the OpenAI Agents SDK, LangChain, and any other OpenAI-compatible library without changing a single line of SDK code — only `base_url` and `api_key` differ.
+
+### Key Facts
+
+| Property | Global | China |
+|---|---|---|
+| **Endpoint** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
+| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
+| **Website** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
+| **API key signup** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
+
+### Why Consider Astraflow for Agentic AI?
+
+- **200+ models via one API key**: Instantly switch between OpenAI, Anthropic, Google, DeepSeek, and open-source models without managing multiple API keys or billing accounts.
+- **OpenAI-compatible**: The exact same `AsyncOpenAI(base_url=..., api_key=...)` pattern used in this repo works out of the box.
+- **Cost efficiency**: As an aggregator, Astraflow often provides competitive pricing — a great fit for students and startups with limited budgets (aligned with the DACA design pattern's goal of minimising costs during training).
+- **Ideal for multi-agent systems**: Different agents in a DACA pipeline can use different best-fit models (e.g., GPT-4o for reasoning, DeepSeek-R1 for STEM, Gemini Flash for speed) — all through a single Astraflow account.
+
+### Quick Start (OpenAI Agents SDK)
+
+```python
+import os
+from openai import AsyncOpenAI
+from agents import Agent, OpenAIChatCompletionsModel, Runner, set_tracing_disabled
+
+# Global endpoint — set ASTRAFLOW_API_KEY in your .env
+astraflow_client = AsyncOpenAI(
+    api_key=os.environ["ASTRAFLOW_API_KEY"],
+    base_url="https://api-us-ca.umodelverse.ai/v1",
+)
+
+set_tracing_disabled(disabled=True)
+
+agent = Agent(
+    name="AstraflowAssistant",
+    instructions="You are a helpful assistant powered by Astraflow.",
+    model=OpenAIChatCompletionsModel(
+        model="gpt-4o",          # swap for any of 200+ supported models
+        openai_client=astraflow_client,
+    ),
+)
+
+result = Runner.run_sync(agent, "Explain the DACA design pattern in one paragraph.")
+print(result.final_output)
+```
+
+> **Sign up**: https://astraflow.ucloud-global.com (global) | https://astraflow.ucloud.cn (China)
+
+---
+
 ## Is my selection of Google Flash correct?")
 
 ---

--- a/01_ai_agents_first/05_model_configuration/readme.md
+++ b/01_ai_agents_first/05_model_configuration/readme.md
@@ -1,4 +1,104 @@
 # [How to configure LLM Providers at different levels (Global, Run and Agent)](https://colab.research.google.com/drive/1nWQny-AxpqQB3HGkyFLBCuai3G4igx6X?usp=sharing)?
+---
+
+## Astraflow Provider Configuration
+
+[Astraflow](https://astraflow.ucloud-global.com) by UCloud is a fully OpenAI-compatible platform supporting **200+ models** through a single API key. Because it is OpenAI-compatible, you configure it the same way as any other third-party provider shown below — just set `base_url` and `api_key`.
+
+**Get your API key**: https://astraflow.ucloud-global.com (global) | https://astraflow.ucloud.cn (China)
+
+### Astraflow — Agent Level
+
+```python
+import os
+import asyncio
+from openai import AsyncOpenAI
+from agents import Agent, OpenAIChatCompletionsModel, Runner, set_tracing_disabled
+
+# Global endpoint — use https://api.modelverse.cn/v1 + ASTRAFLOW_CN_API_KEY for China
+astraflow_client = AsyncOpenAI(
+    api_key=os.environ["ASTRAFLOW_API_KEY"],
+    base_url="https://api-us-ca.umodelverse.ai/v1",
+)
+
+set_tracing_disabled(disabled=True)
+
+async def main():
+    agent = Agent(
+        name="AstraflowAssistant",
+        instructions="You only respond in haikus.",
+        model=OpenAIChatCompletionsModel(
+            model="gpt-4o",   # Any of 200+ models supported by Astraflow
+            openai_client=astraflow_client,
+        ),
+    )
+    result = await Runner.run(agent, "Tell me about recursion in programming.")
+    print(result.final_output)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Astraflow — Run Level
+
+```python
+import os
+from agents import Agent, Runner, AsyncOpenAI, OpenAIChatCompletionsModel
+from agents.run import RunConfig
+
+astraflow_client = AsyncOpenAI(
+    api_key=os.environ["ASTRAFLOW_API_KEY"],
+    base_url="https://api-us-ca.umodelverse.ai/v1",
+)
+
+model = OpenAIChatCompletionsModel(
+    model="gpt-4o",
+    openai_client=astraflow_client,
+)
+
+config = RunConfig(
+    model=model,
+    model_provider=astraflow_client,
+    tracing_disabled=True,
+)
+
+agent = Agent(name="AstraflowAssistant", instructions="You are a helpful assistant")
+result = Runner.run_sync(agent, "Hello, how are you?", run_config=config)
+print(result.final_output)
+```
+
+### Astraflow — Global Level
+
+```python
+import os
+from agents import (
+    Agent, Runner, AsyncOpenAI,
+    set_default_openai_client, set_tracing_disabled, set_default_openai_api,
+)
+
+set_tracing_disabled(True)
+set_default_openai_api("chat_completions")
+
+astraflow_client = AsyncOpenAI(
+    api_key=os.environ["ASTRAFLOW_API_KEY"],
+    base_url="https://api-us-ca.umodelverse.ai/v1",
+)
+set_default_openai_client(astraflow_client)
+
+agent = Agent(
+    name="AstraflowAssistant",
+    instructions="You are a helpful assistant",
+    model="gpt-4o",   # Any of 200+ models supported by Astraflow
+)
+
+result = Runner.run_sync(agent, "Hello")
+print(result.final_output)
+```
+
+> **China users**: replace `base_url` with `https://api.modelverse.cn/v1` and use `os.environ["ASTRAFLOW_CN_API_KEY"]`.
+
+---
+
 
 Agents SDK is setup to use OpenAI as default providers. When using other providers you can setup at different levels:
 1. Agent Level


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider across two key educational files in this repo:

1. **`-01_lets_get_started/00_which_llm/readme.md`** — Introduces Astraflow as a recommended cost-efficient, multi-model aggregation platform alongside existing providers (OpenAI, Gemini, Claude, etc.).

2. **`01_ai_agents_first/05_model_configuration/readme.md`** — Adds ready-to-run code examples showing how to configure Astraflow at the Agent, Run, and Global levels using the OpenAI Agents SDK (since Astraflow is fully OpenAI-compatible).

## About Astraflow

- **What**: OpenAI-compatible AI model aggregation platform by UCloud (优刻得) supporting 200+ models
- **Global endpoint**: `https://api-us-ca.umodelverse.ai/v1` (env var: `ASTRAFLOW_API_KEY`)
- **China endpoint**: `https://api.modelverse.cn/v1` (env var: `ASTRAFLOW_CN_API_KEY`)
- **Website (global)**: https://astraflow.ucloud-global.com
- **Website (China)**: https://astraflow.ucloud.cn
- **API key signup**: https://astraflow.ucloud-global.com

## Why Astraflow fits this repo

- Fully OpenAI-compatible — zero new SDK needed, same `AsyncOpenAI(base_url=..., api_key=...)` pattern already taught in `05_model_configuration`
- 200+ models accessible through a single API key — ideal for students exploring different LLMs
- Cost-efficient aggregation platform — aligns with the DACA design pattern's emphasis on minimizing infrastructure costs during training
- No code changes required in the OpenAI Agents SDK; only `base_url` + `api_key` differ